### PR TITLE
Move the tools variables into a singleton type to maintain state across the application

### DIFF
--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -11,29 +11,32 @@ import (
 
 // Cmd returns the Command used to invoke the installation logic
 func Cmd() *cobra.Command {
+	toolMap := tool.GetMap()
 	installCmd := &cobra.Command{
-		Use:       fmt.Sprintf("install [all|%s]", strings.Join(tool.Names, "|")),
+		Use:       fmt.Sprintf("install [all|%s]", strings.Join(toolMap.Names(), "|")),
 		Args:      cobra.OnlyValidArgs,
-		ValidArgs: append(tool.Names, "all"),
+		ValidArgs: append(toolMap.Names(), "all"),
 		Short:     "Install a new tool",
 		Long:      "Installs one or more tools from the given list. It's valid to specify multiple tools: in this case, all tools provided will be installed. If no specific tools are provided, all are installed by default.",
-		RunE:      run,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return run(cmd, args, toolMap)
+		},
 	}
 	return installCmd
 }
 
 // run installs the tools specified by the provided positional args
-func run(cmd *cobra.Command, args []string) error {
+func run(cmd *cobra.Command, args []string, toolMap tool.Map) error {
 	if len(args) == 0 || utils.Contains(args, "all") {
 		// If user doesn't specify, or explicitly passes 'all', give them all the things
-		args = tool.Names
+		args = toolMap.Names()
 	}
 
 	fmt.Println("Installing the following tools:")
 	installList := []tool.Tool{}
 	for _, toolName := range args {
 		fmt.Printf("- %s\n", toolName)
-		installList = append(installList, tool.Map[toolName])
+		installList = append(installList, toolMap[toolName])
 	}
 
 	err := tool.Install(installList)

--- a/cmd/remove/remove.go
+++ b/cmd/remove/remove.go
@@ -10,19 +10,22 @@ import (
 )
 
 func Cmd() *cobra.Command {
+	toolMap := tool.GetMap()
 	removeCmd := &cobra.Command{
-		Use:       fmt.Sprintf("remove [all|%s]", strings.Join(tool.Names, "|")),
+		Use:       fmt.Sprintf("remove [all|%s]", strings.Join(toolMap.Names(), "|")),
 		Args:      cobra.OnlyValidArgs,
-		ValidArgs: append(tool.Names, "all"),
+		ValidArgs: append(toolMap.Names(), "all"),
 		Short:     "Remove a tool",
 		Long:      "Removes one or more tools from the given list. It's valid to specify multiple tools: in this case, all tools provided will be removed. If 'all' is explicitly passed, then the entire tool directory will be removed, providing a clean slate for reinstall. If no specific tools are provided, no action is taken",
-		RunE:      run,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return run(cmd, args, toolMap)
+		},
 	}
 	return removeCmd
 }
 
 // run removes the tool(s) specified by the provided positional args
-func run(cmd *cobra.Command, args []string) error {
+func run(cmd *cobra.Command, args []string, toolMap tool.Map) error {
 	if len(args) == 0 {
 		fmt.Println("No tools specified to be removed. In order to remove all tools, explicitly specify 'all'")
 		return nil
@@ -35,7 +38,7 @@ func run(cmd *cobra.Command, args []string) error {
 	removeList := []tool.Tool{}
 	for _, toolName := range args {
 		fmt.Printf("- %s\n", toolName)
-		removeList = append(removeList, tool.Map[toolName])
+		removeList = append(removeList, toolMap[toolName])
 	}
 
 	err := tool.Remove(removeList)

--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -11,28 +11,32 @@ import (
 
 // Cmd returns the Command used to invoke the upgrade logic
 func Cmd() *cobra.Command {
+	toolMap := tool.GetMap()
+
 	upgradeCmd := &cobra.Command{
-		Use:       fmt.Sprintf("upgrade [all|%s]", strings.Join(tool.Names, "|")),
+		Use:       fmt.Sprintf("upgrade [all|%s]", strings.Join(toolMap.Names(), "|")),
 		Args:      cobra.OnlyValidArgs,
-		ValidArgs: append(tool.Names, "all"),
+		ValidArgs: append(toolMap.Names(), "all"),
 		Short:     "Upgrade an existing tool",
 		Long:      "Upgrades one or more tools from the provided list. It's valid to specify multiple tools: in this case, all tools provided will be upgraded. If no specific tools are provided, all are (installed and) upgraded by default.",
-		RunE:      run,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return run(cmd, args, toolMap)
+		},
 	}
 	return upgradeCmd
 }
 
-func run(cmd *cobra.Command, args []string) error {
+func run(cmd *cobra.Command, args []string, toolMap tool.Map) error {
 	if len(args) == 0 || utils.Contains(args, "all") {
 		// If user doesn't specify, or explicitly passes 'all', upgrade all the things
-		args = tool.Names
+		args = toolMap.Names()
 	}
 
 	fmt.Println("Upgrading the following tools: ")
 	upgradeList := []tool.Tool{}
 	for _, toolName := range args {
 		fmt.Printf("- %s\n", toolName)
-		upgradeList = append(upgradeList, tool.Map[toolName])
+		upgradeList = append(upgradeList, toolMap[toolName])
 	}
 
 	err := tool.Install(upgradeList)

--- a/pkg/tool/tool.go
+++ b/pkg/tool/tool.go
@@ -2,12 +2,11 @@ package tool
 
 import (
 	"fmt"
+	"github.com/openshift/backplane-tools/pkg/tool/ocm"
+	"github.com/openshift/backplane-tools/pkg/utils"
 	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/openshift/backplane-tools/pkg/tool/ocm"
-	"github.com/openshift/backplane-tools/pkg/utils"
 )
 
 type Tool interface {
@@ -20,19 +19,28 @@ type Tool interface {
 	Remove(rootDir, latestDir string) error
 }
 
-var (
-	Map   map[string]Tool
-	Names []string
-)
+type Map map[string]Tool
 
-func init() {
-	Map = map[string]Tool{}
-	Names = []string{}
+func (m *Map) Names() []string {
+	return utils.Keys(*m)
+}
 
-	// Compile a list of tools available to manage
+var toolMap Map
+
+func newMap() Map {
+	toolMap = Map{}
+
 	ocmTool := ocm.NewTool()
-	Map[ocmTool.Name()] = ocmTool
-	Names = append(Names, ocmTool.Name())
+	toolMap[ocmTool.Name()] = ocmTool
+
+	return toolMap
+}
+
+func GetMap() Map {
+	if toolMap == nil {
+		return newMap()
+	}
+	return toolMap
 }
 
 // Remove removes the provided tools from the install directory

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,10 +1,18 @@
 package utils
 
-func Contains(list []string, val string) bool {
+func Contains[T comparable](list []T, val T) bool {
 	for _, elem := range list {
 		if elem == val {
 			return true
 		}
 	}
 	return false
+}
+
+func Keys[T, U comparable](myMap map[T]U) []T {
+	keys := make([]T, len(myMap))
+	for k := range myMap {
+		keys = append(keys, k)
+	}
+	return keys
 }


### PR DESCRIPTION
This takes takes the Map and Names variables from tool.go, moves them into their own struct to encapsulate state, and provides a method for accessing a singleton instance application wide.